### PR TITLE
First attempt at windows builds

### DIFF
--- a/specs/spark2014.anod
+++ b/specs/spark2014.anod
@@ -13,6 +13,13 @@ class SPARK2014(spec("common")):
         return "11.2.0"
 
     @property
+    def exec_suffix(self):
+        if self.env.host.os.name == "windows":
+            return ".exe"
+        else:
+            return ""
+
+    @property
     def gcc_tarball(self):
         return "gcc-%s.tar.gz" % self.version
 
@@ -108,21 +115,23 @@ class SPARK2014(spec("common")):
         sync_tree(self.deps["why3"]["INSTALL_DIR"], libexec_spark, delete=False)
         sync_tree(self.deps["gcc"]["INSTALL_DIR"], libexec_spark, delete=False)
         sync_tree(self.deps["gprbuild"]["INSTALL_DIR"], libexec_spark, delete=False)
-        cp(os.path.join(self["SRC_DIR"], "z3", "bin", "z3"), libexec_spark_bin)
+        sync_tree(os.path.join(self["SRC_DIR"], "z3"), libexec_spark, delete=False)
+        cvc4_binary_name = "cvc4.exe" if self.env.host.os.name == "windows" else "cvc4"
+        cvc4_binary_name = os.path.join(libexec_spark_bin, cvc4_binary_name)
         cp(
             os.path.join(self["SRC_DIR"], "cvc4", self.cvc4_binary),
-            os.path.join(libexec_spark_bin, "cvc4"),
+            cvc4_binary_name
         )
-        chmod("a+x", os.path.join(libexec_spark_bin, "cvc4"))
+        chmod("a+x", cvc4_binary_name)
         for fn in [
             "gnat2why",
             "spark_codepeer_wrapper",
             "spark_memcached_wrapper",
             "spark_report",
             "spark_semaphore_wrapper",
-            "target.atp",
         ]:
             mv(
-                os.path.join(_bin, fn),
-                os.path.join(libexec_spark, "bin"),
+                os.path.join(_bin, fn + self.exec_suffix),
+                libexec_spark_bin
             )
+        mv (os.path.join(_bin, "target.atp"), libexec_spark_bin)

--- a/specs/why3.anod
+++ b/specs/why3.anod
@@ -2,16 +2,17 @@ from e3.anod.helper import Configure, Make
 from e3.anod.loader import spec
 from e3.anod.package import SourceBuilder
 from e3.anod.spec import Anod
-from e3.fs import cp, mv, sync_tree
+from e3.fs import cp, mv, rm, sync_tree
 from e3.os.fs import chmod
 import os
+import tempfile
 
 
 class Why3(spec("common")):
     @property
     def opam_binary(self):
         if self.env.host.os.name == "windows":
-            assert false
+            fn = "0.0.0.2u.tar.gz"
         elif self.env.host.os.name == "darwin":
             fn = "opam-2.1.0-x86_64-macos"
         else:
@@ -19,13 +20,21 @@ class Why3(spec("common")):
         return fn
 
     @property
+    def opam_url(self):
+        if self.env.host.os.name == "windows":
+            return "https://github.com/kanigsson/opam64/archive/refs/tags/"
+        else:
+            return "https://github.com/ocaml/opam/releases/download/2.1.0/"
+        
+
+    @property
     def source_pkg_build(self):
         return [
             SourceBuilder(name="why3", fullname=lambda: "why3", checkout=["why3"]),
             self.HTTPSSourceBuilder(
                 name=self.opam_binary,
-                url="https://github.com/ocaml/opam/releases/download/2.1.0/%s"
-                % self.opam_binary,
+                url= "%s%s"
+                % (self.opam_url, self.opam_binary),
             ),
             SourceBuilder(
                 name="alt-ergo", fullname=lambda: "alt-ergo", checkout=["alt-ergo"]
@@ -34,10 +43,15 @@ class Why3(spec("common")):
 
     @property
     def build_source_list(self):
+        if self.env.host.os.name == "windows":
+            opam_unpack_cmd = None
+        else:
+            opam_unpack_cmd = cp
+        
         return [
             Anod.Source(name="why3", publish=True, dest="why3"),
             Anod.Source(
-                name=self.opam_binary, publish=True, unpack_cmd=cp, dest="opam"
+                name=self.opam_binary, publish=True, unpack_cmd=opam_unpack_cmd, dest="opam"
             ),
             Anod.Source(name="alt-ergo", publish=True, dest="alt-ergo"),
         ]
@@ -46,7 +60,7 @@ class Why3(spec("common")):
         opam_binary = os.path.join(self["SRC_DIR"], "opam", self.opam_binary)
         chmod("u+x", opam_binary)
         opamroot = os.path.join(self["TMP_DIR"])
-        self.shell(opam_binary, "init", "--root=" + opamroot, "-n")
+        self.shell(opam_binary, "init", "--root=" + opamroot, "-n", "--disable-sandboxing")
         self.shell(
             opam_binary,
             "install",
@@ -65,6 +79,48 @@ class Why3(spec("common")):
         )
         opam_bin_path = os.path.join(self["TMP_DIR"], "default", "bin")
         self.env.add_path(opam_bin_path)
+
+    def build_opam_win(self):
+        rm(self["TMP_DIR"])
+        tmpdir = self["TMP_DIR"]
+        opam_dir = os.path.join(self["SRC_DIR"], "opam")
+        opamroot = os.path.join(tmpdir, "opamroot")
+        self.shell("bash", os.path.join(opam_dir, "install.sh"), "--prefix", tmpdir)
+        opam_binary = os.path.join(opam_dir, "bin", "opam")
+        variant = "ocaml-variants.4.10.0+mingw64c"
+        self.shell(
+            opam_binary,
+            "init",
+            "default",
+            "https://github.com/fdopen/opam-repository-mingw.git#opam2",
+            "-c",
+            variant,
+            "--disable-sandboxing",
+            "--root=" + opamroot,
+            "-n",
+            "-y",
+        )
+        os.environ["C_INCLUDE_PATH"] = "/usr/include"
+        os.environ["LDFLAGS"] = "-L/usr/lib"
+        self.shell(
+            opam_binary,
+            "install",
+            "--root=" + opamroot,
+            "-y",
+            "camlzip",
+            "menhir",
+            "num",
+            "ocamlgraph",
+            "ocplib-simplex",
+            "psmt2-frontend",
+            "re",
+            "seq",
+            "yojson",
+            "zarith",
+        )
+        variant_dir = os.path.join(opamroot, variant)
+        self.env.add_path(os.path.join(variant_dir, "bin"))
+        os.environ["OCAMLLIB"]= os.path.join(variant_dir, "lib", "ocaml")
 
     def build_altergo(self):
         installdir = os.path.join(self["PKG_DIR"], "alt-ergo")
@@ -113,6 +169,7 @@ class Why3(spec("common")):
             "--disable-js-of-ocaml",
             "--prefix=%s" % os.path.join(self["PKG_DIR"], "why3"),
         )
+        os.environ["CONFIG_SHELL"] = "bash"
         configure()
         make = Make(self, exec_dir=src_dir)
         make()
@@ -120,7 +177,10 @@ class Why3(spec("common")):
 
     @Anod.primitive(post="install")
     def build(self):
-        self.build_opam()
+        if self.env.host.os.name == "windows":
+            self.build_opam_win()
+        else:
+            self.build_opam()
         self.build_why3()
         self.build_altergo()
         self.install()


### PR DESCRIPTION
I am following this guide:

https://gist.github.com/mnxn/93009346c1bd56f387daf28413152179

which means that for this to work, we need (at least) those packages:
```rsync patch diffutils curl make unzip git m4 perl tar mingw-w64-cross-gcc mingw-w64-x86_64-pkg-config```
Also, `/opt/bin` should be in the `$PATH`.
On my machine, I had to set `CONFIG_SHELL` to `bash`, but I had the same issue with the gcc/mingw64 builds, so it might just be related to my setup.
Finally the resulting binary of why3 requires copying a dll in the install, I haven't implemented this yet. But the build should work in theory.
Also, I haven't tested yet that these changes don't break linux builds.