### PR TITLE
msp430-elf toolchain

### DIFF
--- a/lib/platform_db.py
+++ b/lib/platform_db.py
@@ -4,6 +4,7 @@ class PlatDB(PlatformDBPlugin):
     def update_db(self) -> None:
         self.cpu_info.update(
             {
+                "msp430": {"endian": "little", "bits": 16},
                 "riscv32": {"endian": "little", "bits": 32},
                 "riscv64": {"endian": "little", "bits": 64},
             }
@@ -32,6 +33,7 @@ class PlatDB(PlatformDBPlugin):
 
         self.platform_info.update(
             {
+                "msp430-elf": {"cpu": "msp430", "os": "none", "is_hie": True},
                 "riscv32-elf": {"cpu": "riscv32", "os": "none", "is_hie": True},
                 "riscv64-elf": {"cpu": "riscv64", "os": "none", "is_hie": True},
                 "riscv32-unknown-elf": {"cpu": "riscv32", "os": "none", "is_hie": True},
@@ -41,10 +43,10 @@ class PlatDB(PlatformDBPlugin):
 
         self.build_targets.update(
             {
+                "msp430-elf": {"name": "msp430-elf"},
                 "riscv32-elf": {"name": "riscv32-elf"},
                 "riscv64-elf": {"name": "riscv64-elf"},
                 "riscv32-unknown-elf": {"name": "riscv32-unknown-elf"},
                 "riscv64-unknown-elf": {"name": "riscv64-unknown-elf"},
-
             }
         )

--- a/specs/gcc.anod
+++ b/specs/gcc.anod
@@ -39,6 +39,7 @@ class GCC(spec("gh-artifact")):
             self.env.target.triplet == "arm-eabi"
             or self.env.target.triplet == "riscv64-elf"
             or self.env.target.triplet == "avr-elf"
+            or self.env.target.triplet == "msp430-elf"
         )
 
     @property
@@ -163,6 +164,10 @@ class GCC(spec("gh-artifact")):
             args.append("--with-multilib-list=rmprofile")
 
         if self.env.target.triplet == "riscv64-elf":
+            args += cross_commons
+            args.append("--enable-multilib")
+
+        if self.env.target.triplet == "msp430-elf":
             args += cross_commons
             args.append("--enable-multilib")
 

--- a/specs/release_package.anod
+++ b/specs/release_package.anod
@@ -59,6 +59,8 @@ class ReleasePackage(spec("common")):
                 return "1"
             elif self.env.target.triplet == "avr-elf":
                 return "1"
+            elif self.env.target.triplet == "msp430-elf":
+                return "1"
             else:
                 return "1"
 
@@ -123,11 +125,23 @@ class ReleasePackage(spec("common")):
                     Anod.Dependency("embedded-runtimes", track=True),
                 ]
 
+            elif self.env.target.triplet == "msp430":
+                return [
+                    Anod.Dependency("gcc", track=True),
+                    Anod.Dependency("gdb", track=True),
+                ]
+
             elif self.env.target.triplet == "avr":
                 return [
                     Anod.Dependency("gcc", track=True),
                     Anod.Dependency("gdb", track=True),
                     Anod.Dependency("avrlibc", track=True),
+                ]
+
+            elif self.env.target.triplet == "msp430-elf":
+                return [
+                    Anod.Dependency("gcc", track=True),
+                    Anod.Dependency("gdb", track=True),
                 ]
 
             elif self.env.host.triplet == self.env.target.triplet:


### PR DESCRIPTION
Before this toolchain is useful to anyone, the msp430-elf target needs to be added to gprconfig_kb in order for gprbuild to find it. I did that in [this commit](https://github.com/AdaCore/gprconfig_kb/commit/f5db7aa4e71fe64eb151fed3376051fad9737ec6), based on gprconfig_kb's master branch. GNAT-FSF-builds uses the 22.0.0 release of gprconfig_kb, so we'll either need to backport this patch or switch to a newer version.

I ported TI's blink demo to SPARK/Ada, using bare_runtime:
https://github.com/JeremyGrosser/msp430test/blob/master/src/msp430test.adb

The main procedure passes gnatprove verification, but bare_runtime does not, so analysis of those units is skipped.