### PR TITLE
Statically link gdb

### DIFF
--- a/specs/gdb.anod
+++ b/specs/gdb.anod
@@ -81,7 +81,9 @@ class GDB(spec("common")):
             "--disable-plugins",
             "--disable-gdbserver",
             "--with-static-standard-libraries",
-            "--disable-source-highlight",  # Incomaptible with static std libs
+            "--enable-static",
+            "--disable-interprocess-agent", # Incompatible with static linking
+            "--disable-source-highlight",   # Incompatible with static std libs
             "--with-curses",
             "--disable-sim",
             "--with-mpfr",

--- a/specs/isl.anod
+++ b/specs/isl.anod
@@ -17,7 +17,7 @@ class ISL(spec("gnu")):
     def source_pkg_build(self):
         return [
             self.HTTPSSourceBuilder(
-                name=self.tarball, url="https://libisl.sourceforge.io/" + self.tarball
+                name=self.tarball, url="https://gcc.gnu.org/pub/gcc/infrastructure/" + self.tarball
             )
         ]
 


### PR DESCRIPTION
Found the right combination of configure switches in this stackoverflow thread: https://stackoverflow.com/questions/9364685/how-i-can-static-build-gdb-from-source

Note that this also disables the [In-Process Agent](https://sourceware.org/gdb/onlinedocs/gdb/In_002dProcess-Agent.html), which is incompatible with static linking. As far as I know, nobody uses this with Ada.