### PR TITLE
Add scripts for MacOS X for ARM compiler

### DIFF
--- a/.github/workflows/macos_arm.yml
+++ b/.github/workflows/macos_arm.yml
@@ -1,0 +1,169 @@
+name: macOS_arm
+on:
+  pull_request:
+
+
+jobs:
+  gnat_gprbuild:
+    name: GNAT macOS
+    runs-on: macos-14
+    steps:
+    - name: Checkout Project
+      uses: actions/checkout@v2
+
+    - name: Install texinfo with Homebrew
+      run: brew install texinfo
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.10.11
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install e3-core==22.1.0
+
+    - name: Build GNAT native
+      run: ./anod build gcc -v --loglevel DEBUG --enable-cleanup
+
+    - name: Build GDB
+      run: ./anod build gdb -v --loglevel DEBUG --enable-cleanup
+
+    - name: Package GNAT
+      run: ./anod build release_package --qualifier=package=gnat,do_gh_release -v --loglevel DEBUG
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for GitHub CLI tool
+
+    - name: Build GPRbuild
+      run: ./anod build gprbuild -v --loglevel DEBUG --enable-cleanup
+
+    - name: Package GPRbuild
+      run: ./anod build release_package --qualifier=package=gprbuild,do_gh_release -v --loglevel DEBUG
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for GitHub CLI tool
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: anod-artifacts
+        path: out_artifacts/*
+        retention-days: 1
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: release-packages
+        path: sbx/*/release_package*/install/*
+        retention-days: 5
+
+
+
+  why3:
+    strategy:
+      matrix:
+        ocaml-compiler:
+          - 4.12.1
+    runs-on: macos-14
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          repository: 'adacore/why3'
+          ref: 'fsf-13'
+
+      - name: Use Setup OCaml {{ matrix.ocaml-version }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler}}
+
+      - name: Setup Packages
+        run: |
+          opam depext zarith re seq why3
+          opam install dune dune-configurator menhir num ocamlgraph re seq yojson zarith sexplib ppx_sexp_conv ppx_deriving
+
+      - run: opam exec -- ./configure --prefix=/tmp/why3install --enable-relocation --disable-emacs-compilation --disable-hypothesis-selection --disable-js-of-ocaml --disable-zip
+
+      - run: opam exec -- make
+
+      - run: opam exec -- make install_spark2014
+
+      - run: git log --format="%H" -n 1 > /tmp/why3install/why3-version.txt
+
+      - name: Upload the build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: why3
+          path: /tmp/why3install
+
+
+  alt_ergo:
+    strategy:
+      matrix:
+        ocaml-compiler:
+          - 4.12.1
+
+    runs-on: macos-14
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          repository: 'adacore/alt-ergo'
+          ref: 'master'
+
+      - name: Use Setup OCaml {{ matrix.ocaml-version }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - run: opam install alt-ergo --destdir=/tmp/alt-ergo-install
+
+      - run: git log --format="%H" -n 1 > /tmp/alt-ergo-install/alt-ergo-version.txt
+
+      - name: Upload the build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: alt-ergo
+          path: /tmp/alt-ergo-install
+
+
+
+  spark:
+    name: SPARK
+    needs: [why3, alt_ergo]
+    runs-on: macos-14
+    steps:
+    - name: Checkout Project
+      uses: actions/checkout@v2
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: alt-ergo
+        path: alt-ergo_artifact/
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: why3
+        path: why3_artifact/
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.10.11
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install e3-core==22.1.0
+
+    - name: Build SPARK
+      run: ./anod build spark2014 -v --loglevel DEBUG --enable-cleanup
+
+    - name: Package GNATprove
+      run: ./anod build release_package --qualifier=package=gnatprove,do_gh_release -v --loglevel DEBUG
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for GitHub CLI tool
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: release-packages
+        path: sbx/*/release_package*/install/*
+        retention-days: 5

--- a/lib/platform_db.py
+++ b/lib/platform_db.py
@@ -23,6 +23,7 @@ class PlatDB(PlatformDBPlugin):
         self.host_guess.pop("x86-windows")
         self.host_guess.update(
             {
+                "aarch64-darwin": {"os": "Darwin", "cpu": "arm64"},
                 "x86_64-windows64": {
                     "os": "Windows",
                     "cpu": "AMD64",
@@ -32,6 +33,7 @@ class PlatDB(PlatformDBPlugin):
 
         self.platform_info.update(
             {
+                "aarch64-darwin": {"cpu": "aarch64", "os": "darwin", "is_hie": False},
                 "riscv32-elf": {"cpu": "riscv32", "os": "none", "is_hie": True},
                 "riscv64-elf": {"cpu": "riscv64", "os": "none", "is_hie": True},
                 "riscv32-unknown-elf": {"cpu": "riscv32", "os": "none", "is_hie": True},
@@ -41,6 +43,7 @@ class PlatDB(PlatformDBPlugin):
 
         self.build_targets.update(
             {
+                "aarch64-darwin": {"name": "aarch64-apple-darwin%(os_version)s"},
                 "riscv32-elf": {"name": "riscv32-elf"},
                 "riscv64-elf": {"name": "riscv64-elf"},
                 "riscv32-unknown-elf": {"name": "riscv32-unknown-elf"},

--- a/specs/base_gcc.anod
+++ b/specs/base_gcc.anod
@@ -12,13 +12,21 @@ class base_gcc(spec("common")):
 
     @property
     def tarball(self):
-        return "gnat-%s-%s.tar.gz" % (self.env.platform, self.version)
+        return (
+            "gnat-%s-%s.tar.gz" % (self.env.platform, self.version)
+            if self.env.target.cpu.name == "x86_64"
+            # To be reverted after the bootstrap
+            else "gnat-macos-aarch64-13.2.1.tar.gz"
+        )
 
     @property
     def url(self):
         return (
             "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-%s/%s"
             % (self.version, self.tarball)
+            if self.env.target.cpu.name == "x86_64" else
+            "https://github.com/simonjwright/alire-index.mac/releases/download/toolchain-13.2.1/%s"
+            % (self.tarball)
         )
 
     @Anod.primitive()

--- a/specs/gcc.anod
+++ b/specs/gcc.anod
@@ -4,8 +4,11 @@ from e3.anod.helper import Configure, Make
 from e3.anod.spec import Anod
 from e3.anod.loader import spec
 from e3.env import Env
+from e3.os.process import Run
 import os
 
+# A wrapper to call ld-classic on MacOS X
+patch_name = "ld"
 
 class GCC(spec("gh-artifact")):
     @property
@@ -21,14 +24,24 @@ class GCC(spec("gh-artifact")):
         return [
             self.HTTPSSourceBuilder(
                 name=self.tarball,
-                url="https://ftp.gnu.org/gnu/gcc/gcc-%s/%s"
-                % (self.version, self.tarball),
-            )
+                url=(
+                    "https://ftp.gnu.org/gnu/gcc/gcc-%s/%s"
+                    % (self.version, self.tarball)
+                    if self.env.target.cpu.name == "x86_64"
+                    else
+                    "https://github.com/iains/gcc-13-branch/archive/refs/"
+                    + "tags/gcc-13.2-darwin-r0.tar.gz"
+                )
+            ),
+            self.LocalSourceBuilder(name=patch_name)
         ]
 
     @property
     def build_source_list(self):
-        return [Anod.Source(name=self.tarball, publish=True, dest="")]
+        return [
+            Anod.Source(name=self.tarball, publish=True, dest=""),
+            self.Source(name=patch_name, publish=True, unpack_cmd=cp, dest="patches")
+        ]
 
     @property
     def bootstrap(self):
@@ -287,4 +300,13 @@ class GCC(spec("gh-artifact")):
                 delete=False,
             )
 
+        # Add ld-classic wrapper
+        if self.env.target.os.name == "darwin":
+            gcc = os.path.join(self["INSTALL_DIR"], "bin", "gcc")
+            p = Run([gcc, "--print-prog-name=cc1"])
+            libexec = os.path.dirname(p.out.strip())
+            cp(
+                os.path.join(self["SRC_DIR"], "patches", patch_name),
+                libexec,
+            )
         self.clean()

--- a/specs/gpr2.anod
+++ b/specs/gpr2.anod
@@ -39,7 +39,7 @@ class LibGPR2(spec("common")):
 
     @property
     def build_deps(self):
-        return [
+        deps = [
             Anod.Dependency("base_gcc", track=True),
             Anod.Dependency("gprbuild", track=True),
             Anod.Dependency("xmlada", track=True),
@@ -47,7 +47,13 @@ class LibGPR2(spec("common")):
             Anod.Dependency("gnatcoll", track=True),
             Anod.Dependency("gnatcoll-bindings", track=True),
             Anod.Dependency("gprconfig_kb", track=True),
+            Anod.Dependency("gmp", track=True),
         ]
+        # gnatcoll-bindings doesn't pass -Lgmp&iconv, so let's depend on them
+        if self.env.target.os.name == "windows":
+            deps.append(Anod.Dependency("libiconv", track=True))
+
+        return deps
 
     def update_version(self):
         text_replace(

--- a/specs/gprbuild.anod
+++ b/specs/gprbuild.anod
@@ -3,8 +3,11 @@ from e3.fs import sync_tree, cp
 from e3.anod.helper import Make, text_replace
 from e3.anod.spec import Anod
 from e3.anod.loader import spec
+from e3.diff import patch
 import os
 from datetime import date
+
+patch_name = "gprbuild-no-static.patch"
 
 class GPRbuild(spec("gh-artifact")):
     @property
@@ -23,6 +26,7 @@ class GPRbuild(spec("gh-artifact")):
                 url="https://github.com/AdaCore/gprbuild/archive/v%s/%s"
                 % (self.version, self.tarball),
             ),
+            self.LocalSourceBuilder(name=patch_name),
         ]
 
     @property
@@ -38,6 +42,7 @@ class GPRbuild(spec("gh-artifact")):
                 Anod.Source(
                     name=self.deps["xmlada"].tarball, publish=True, dest="xmlada"
                 ),
+                Anod.Source(name=patch_name, publish=True, unpack_cmd=cp, dest="patches"),
             ]
         else:
             return [
@@ -47,6 +52,7 @@ class GPRbuild(spec("gh-artifact")):
                     publish=True,
                     dest="gprconfig_kb",
                 ),
+                Anod.Source(name=patch_name, publish=True, unpack_cmd=cp, dest="patches"),
             ]
 
     @property
@@ -134,6 +140,13 @@ class GPRbuild(spec("gh-artifact")):
         # build method.
 
         self.update_version()
+
+        if self.env.host.os.name == "darwin":
+            # MacOS X can't execute 'gcc -static', patching gprbuild
+            patch(
+                os.path.join(self["SRC_DIR"], "patches", patch_name),
+                self.build_space.src_dir,
+            )
 
         if self.bootstrap:
             return self.do_bootstrap()

--- a/specs/gprconfig_kb.anod
+++ b/specs/gprconfig_kb.anod
@@ -5,7 +5,7 @@ from e3.anod.loader import spec
 class GPRconfig_KB(spec("common")):
     @property
     def version(self):
-        return "22.0.0"
+        return "23.0.0"
 
     @property
     def tarball(self):

--- a/specs/mingw.anod
+++ b/specs/mingw.anod
@@ -21,7 +21,7 @@ class MINGW(spec("common")):
         return [
             self.HTTPSSourceBuilder(
                 name=self.tarball,
-                url="https://nav.dl.sourceforge.net/project/mingw-w64/mingw-w64/mingw-w64-release/"
+                url="https://download.sourceforge.net/project/mingw-w64/mingw-w64/mingw-w64-release/"
                 + self.tarball,
             )
         ]

--- a/specs/patches/gprbuild-no-static.patch
+++ b/specs/patches/gprbuild-no-static.patch
@@ -1,0 +1,11 @@
+diff -Naur src/gprbuild-link.adb src/gprbuild-link.adb
+--- src/gprbuild-link.adb	2023-10-09 21:31:11.000000000 +0300
++++ src/gprbuild-link.adb	2024-03-12 23:46:51.766005336 +0200
+@@ -1880,6 +1880,7 @@
+                               when Resulting_Options =>
+                                  if not Apply_Bindfile_Option_Substitution
+                                           (Line (1 .. Last))
++                                    and then Line (1 .. Last) /= "-static"
+                                  then
+                                     Binding_Options.Append (Line (1 .. Last));
+                                  end if;

--- a/specs/patches/ld
+++ b/specs/patches/ld
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+classic=$(xcrun --find ld-classic 2>/dev/null) || true
+
+if [ -n "$classic" ]; then
+    exec $classic "$@"
+else
+    exec ld "$@"
+fi
+

--- a/specs/zlib.anod
+++ b/specs/zlib.anod
@@ -10,7 +10,7 @@ import os
 class ZLib(spec("common")):
     @property
     def version(self):
-        return "1.3"
+        return "1.3.1"
 
     @property
     def tarball(self):
@@ -20,7 +20,7 @@ class ZLib(spec("common")):
     def source_pkg_build(self):
         return [
             self.HTTPSSourceBuilder(
-                name=self.tarball, url="https://zlib.net/current/%s" % self.tarball
+                name=self.tarball, url="https://zlib.net/%s" % self.tarball
             ),
         ]
 


### PR DESCRIPTION
This PR builds `gnat-aarch64-darwin-13.2.0-x.tar.gz` for MacOS X ARM.

I've dropped `gprbuild` part, because I can't build it. Version 24.0 fails (even on x86_64) because the script calls `gcc -static` while linking gprbuild executable and MacOS X doesn't support static linking. To be investigated.

Cross should work for arm and riscv when gprbuild is ready. But avrlib fails fails with `machine `aarch64-apple' not recognized`. However cross archives have name collision: both x86_64 and arm64 have name `gnat-riscv64-elf-darwin-13.2.0-1.tar.gz` 

SPARK depends on gnatcoll/gprbuild also.

XRef: https://github.com/alire-project/alire/discussions/1492
