### PR TITLE
Build GCC 14.1 on aarch64-apple-darwin.

### DIFF
--- a/.github/workflows/macos_arm.yml
+++ b/.github/workflows/macos_arm.yml
@@ -8,6 +8,9 @@ jobs:
     name: GNAT macOS
     runs-on: macos-14
     steps:
+    - name: Set Xcode 15.3
+      run: sudo xcode-select --switch /Applications/Xcode_15.3.app
+
     - name: Checkout Project
       uses: actions/checkout@v2
 
@@ -133,6 +136,9 @@ jobs:
     steps:
     - name: Checkout Project
       uses: actions/checkout@v2
+
+    - name: Set Xcode 15.3
+      run: sudo xcode-select --switch /Applications/Xcode_15.3.app
 
     - uses: actions/download-artifact@v2
       with:

--- a/specs/base_gcc.anod
+++ b/specs/base_gcc.anod
@@ -16,8 +16,11 @@ class base_gcc(spec("common")):
 
     @property
     def url(self):
-        return "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-%s/%s" \
+        # Use Simon's GCC 13.3 compiler on Mac OS X ARM64 for bootstrap
+        return ("https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-%s/%s" \
                     % (self.version, self.tarball)
+                if self.env.target.cpu.name == "x86_64" else
+                "https://github.com/simonjwright/alire-index.mac/releases/download/toolchain-13.2.1/gcc-13.3.0-aarch64.tar.gz")
 
     @Anod.primitive()
     def build(self):
@@ -25,7 +28,7 @@ class base_gcc(spec("common")):
         with HTTPSession() as http:
             http.download_file(self.url, self["BUILD_DIR"], self.tarball)
 
-        # Exctract the archive
+        # Extract the archive
         unpack_archive(self.tarball, self["INSTALL_DIR"], remove_root_dir=True)
 
         # Delete the archive

--- a/specs/gcc.anod
+++ b/specs/gcc.anod
@@ -30,7 +30,7 @@ class GCC(spec("gh-artifact")):
                     if self.env.target.cpu.name == "x86_64"
                     else
                     "https://github.com/iains/gcc-14-branch/archive/refs/"
-                    + "tags/gcc-14.1-darwin-r0.tar.gz"
+                    + "tags/gcc-14.1-darwin-r1.tar.gz"
                 )
             ),
             self.LocalSourceBuilder(name=patch_name)
@@ -139,10 +139,6 @@ class GCC(spec("gh-artifact")):
             args.append("--disable-multilib")
 
             args.append("--disable-libcilkrts")
-
-            # Workaround for Xcode 12.5 bug on Intel
-            # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100340
-            args.append("--without-build-config")
 
             xcode = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
             clu = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"


### PR DESCRIPTION
Use Xcode 15.3, because (at this time) the macos-14 runner defaults to Xcode 15.0.1, which has the linking bug. 15.3 is the latest version available in Command Line Tools; Xcode has 15.4.

Use GCC 13.3.0 as the base compiler, because (on Github) 13.2 links one of the tools generated during the compiler build in such a way that it won't run.

Update GNAT's aarch64 source to the gcc-14.1-darwin-r1 release.

Don't configure GCC with --without-build-config (the reason for using it was GCC PR 100340, which was fixed in 2022; using it caused failures in bootstrap stage 2/3 comparison).

  * .github/workflows/macos_arm.yml (GNAT macOS): use Xcode 15.3. (SPARK): likewise.
  * specs/base_gcc.anod (tarball): directly name the 13.3.0 build to be used. (url): directly name the location of the 13.3.0 build to be used.
  * specs/gcc.anod (source_pkg_build): update to the gcc-14.1-darwin-r1 release. (configure_args): don't use --without-build-config.

Refs #67