### PR TITLE
gmp: apply cstd downgrade for all host types

### DIFF
--- a/specs/gmp.anod
+++ b/specs/gmp.anod
@@ -60,9 +60,7 @@ class GMP(spec("gnu")):
             # https://github.com/Homebrew/homebrew-core/blob/98064198c7e5464124f53bbdb47bec3e03f1a0cd/Formula/gmp.rb#L28
             configure.add("--with-pic")
 
-        if self.env.host.os.name == "windows":
-            configure.add("CFLAGS=-std=gnu17")  # fix for new defaults in gcc 15.1.0
-
+        configure.add("CFLAGS=-std=gnu17")  # fix for new defaults in gcc 15.1.0
         make = Make(self)
 
         return {"configure": configure, "make": make}


### PR DESCRIPTION
All platforms are affected by the bump in default C standard version in GCC 15.

Remove the erroneous restriction to Windows.
Fixes #104.